### PR TITLE
Fix serializer/unserialize Adobe Marketplace

### DIFF
--- a/Gateway/Http/Transactions.php
+++ b/Gateway/Http/Transactions.php
@@ -14,6 +14,7 @@ namespace Shipay\PixQrGateway\Gateway\Http;
 
 use Magento\Framework\Exception\LocalizedException;
 use Psr\Log\LoggerInterface;
+use Magento\Framework\Serialize\SerializerInterface;
 
 abstract class Transactions
 {
@@ -38,19 +39,27 @@ abstract class Transactions
     protected $token;
 
     /**
+     * @var SerializerInterface
+     */
+    protected $serializer;
+
+    /**
      * GetPixTransaction constructor.
      * @param LoggerInterface $logger
      * @param TokenGenerator $tokenGenerator
      * @param UrlResolver $urlResolver
+     * @param SerializerInterface $serializer
      */
     public function __construct(
         LoggerInterface $logger,
         TokenGenerator $tokenGenerator,
-        UrlResolver $urlResolver
+        UrlResolver $urlResolver,
+        SerializerInterface $serializer
     ) {
         $this->logger = $logger;
         $this->tokenGenerator = $tokenGenerator;
         $this->urlResolver = $urlResolver;
+        $this->serializer = $serializer;
     }
 
     /**
@@ -75,7 +84,7 @@ abstract class Transactions
             curl_close($channel);
 
             if ($response !== false) {
-                return json_decode($response, true);
+                return $this->serializer->unserialize($response);
             }
         } catch (\Exception $exception) {
             $this->logger->critical($exception);


### PR DESCRIPTION
**Erro:**
The use of function unserialize() is forbidden; use \\Magento\\Framework\\Serialize\\SerializerInterface::unserialize() instead.

**Correção:** 
Foi injetado a classe do magento/framework para usar os métodos unserilize/serialize assim deixando o módulo compatível para ser publicado no marketplace. 